### PR TITLE
Explicitly set the console encoding to utf8.

### DIFF
--- a/Nexus.vcxproj
+++ b/Nexus.vcxproj
@@ -456,6 +456,7 @@
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -488,6 +489,7 @@ CALL $(SolutionDir)Scripts\version.bat</Command>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/Events/EventHandler.cpp
+++ b/src/Events/EventHandler.cpp
@@ -69,7 +69,7 @@ void CEventApi::Raise(const char* aIdentifier, void* aEventData)
 
 	//auto end_time = std::chrono::high_resolution_clock::now();
 	//auto time = end_time - start_time;
-	//Logger->Debug(CH_EVENTS, u8"Executed event (%s) in %uµs.", aIdentifier, time / std::chrono::microseconds(1));
+	//Logger->Debug(CH_EVENTS, u8"Executed event (%s) in %uÂµs.", aIdentifier, time / std::chrono::microseconds(1));
 }
 
 void CEventApi::Raise(signed int aSignature, const char* aIdentifier, void* aEventData)

--- a/src/GUI/GUI.cpp
+++ b/src/GUI/GUI.cpp
@@ -517,13 +517,13 @@ namespace GUI
 			Language->SetLanguage("English");
 			break;
 		case 2:
-			Language->SetLanguage("Français");
+			Language->SetLanguage("FranÃ§ais");
 			break;
 		case 3:
 			Language->SetLanguage("Deutsch");
 			break;
 		case 4:
-			Language->SetLanguage(u8"Español");
+			Language->SetLanguage(u8"EspaÃ±ol");
 			break;
 		/*case 5:
 			Language.SetLanguage(u8"Chinese");

--- a/src/GUI/Widgets/About/CAboutBox.cpp
+++ b/src/GUI/Widgets/About/CAboutBox.cpp
@@ -61,10 +61,10 @@ namespace GUI
 			ImGui::Separator();
 
 			ImVec2 windowSize = ImGui::GetWindowSize();
-			ImVec2 textSize = ImGui::CalcTextSize(u8"Raidcore © 2023 - 2024");
+			ImVec2 textSize = ImGui::CalcTextSize(u8"Raidcore Â© 2023 - 2024");
 			ImVec2 position = ImGui::GetCursorPos();
 			ImGui::SetCursorPos(ImVec2((position.x + (windowSize.x - textSize.x)) / 2, position.y));
-			ImGui::Text(u8"Raidcore © 2023 - 2024");
+			ImGui::Text(u8"Raidcore Â© 2023 - 2024");
 		}
 		ImGui::End();
 	}

--- a/src/Loader/Loader.cpp
+++ b/src/Loader/Loader.cpp
@@ -815,7 +815,7 @@ namespace Loader
 		addon->State = locked ? EAddonState::LoadedLOCKED : EAddonState::Loaded;
 		SaveAddonConfig();
 
-		Logger->Info(CH_LOADER, u8"Loaded addon: %s (Signature %d) [%p - %p] (API Version %d was requested.) Took %uµs.", 
+		Logger->Info(CH_LOADER, u8"Loaded addon: %s (Signature %d) [%p - %p] (API Version %d was requested.) Took %uÂµs.", 
 			strFile.c_str(), addon->Definitions->Signature,
 			addon->Module, ((PBYTE)addon->Module) + moduleInfo.SizeOfImage,
 			addon->Definitions->APIVersion, time / std::chrono::microseconds(1)
@@ -897,7 +897,7 @@ namespace Loader
 		}
 
 		aAddon->IsWaitingForUnload = false;
-		Logger->Info(CH_LOADER, u8"Unloaded addon: %s (Took %uµs.)", aPath.filename().string().c_str(), time / std::chrono::microseconds(1));
+		Logger->Info(CH_LOADER, u8"Unloaded addon: %s (Took %uÂµs.)", aPath.filename().string().c_str(), time / std::chrono::microseconds(1));
 	}
 
 	void UnloadAddon(const std::filesystem::path& aPath, bool aDoReload)

--- a/src/Services/Logging/CConsoleLogger.cpp
+++ b/src/Services/Logging/CConsoleLogger.cpp
@@ -22,6 +22,10 @@ CConsoleLogger::CConsoleLogger(ELogLevel aLogLevel)
 	freopen_s(&iobuf, "CONIN$", "r", stdin);
 	freopen_s(&iobuf, "CONOUT$", "w", stderr);
 	freopen_s(&iobuf, "CONOUT$", "w", stdout);
+	//NOTE(Rennorb): Set the console to utf8 mode.
+	// This is required for the µ (mu) symbol used in the timing logs.
+	// By default Windows uses a codepage specific to the selected locale, which wich likely doesn't have that symbol
+	SetConsoleOutputCP(CP_UTF8);
 	hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 }
 


### PR DESCRIPTION
It was just using whatever your console is currently set to before. Causing the symbols to be corrupted at random.

This also converts the mu symbols to utf8.

The imgui log still works just the same.