### PR TITLE
Added an option to suppress mumble parsing errors after the first 5

### DIFF
--- a/src/GUI/GUI.cpp
+++ b/src/GUI/GUI.cpp
@@ -693,6 +693,17 @@ namespace GUI
 				Settings::Settings[OPT_LINKARCSTYLE] = true;
 			}
 
+			if (!Settings::Settings[OPT_SUPPRESS_EXCESSIVE_MUMBLE_PARSE_ERRORS].is_null())
+			{
+				Settings::Settings[OPT_SUPPRESS_EXCESSIVE_MUMBLE_PARSE_ERRORS].get_to(*(bool*)&Mumble::SuppressExcessiveParseErrors);
+			}
+			else
+			{
+				Mumble::SuppressExcessiveParseErrors = false;
+				Settings::Settings[OPT_SUPPRESS_EXCESSIVE_MUMBLE_PARSE_ERRORS] = false;
+			}
+
+
 			ImGuiStyle* style = &ImGui::GetStyle();
 			if (!Settings::Settings[OPT_IMGUISTYLE].is_null())
 			{

--- a/src/GUI/Widgets/Options/COptionsWindow.cpp
+++ b/src/GUI/Widgets/Options/COptionsWindow.cpp
@@ -15,6 +15,7 @@
 #include "Services/API/APIController.h"
 #include "Services/Localization/Localization.h"
 #include "Services/Settings/Settings.h"
+#include "Services/Mumble/Reader.h"
 
 #include "Util/Base64.h"
 
@@ -201,6 +202,18 @@ namespace GUI
 						Settings::Settings[OPT_QAOFFSETY] = QuickAccess::Offset.y;
 						Settings::Save();
 					}
+				}
+
+				ImGui::Separator();
+
+				ImGui::TextDisabled(Language->Translate("log_settings"));
+				{
+					if (ImGui::Checkbox(Language->Translate("supress_excessive_mumble_parsing_errors"), (bool*)&Mumble::SuppressExcessiveParseErrors))
+					{
+						Settings::Settings[OPT_SUPPRESS_EXCESSIVE_MUMBLE_PARSE_ERRORS] = Mumble::SuppressExcessiveParseErrors;
+						Settings::Save();
+					}
+					ImGui::TextDisabled(Language->Translate("parse_errors_so_far_%u"), Mumble::ParserErrorCount);
 				}
 
 				ImGui::EndChild();

--- a/src/Services/Mumble/Reader.h
+++ b/src/Services/Mumble/Reader.h
@@ -30,6 +30,8 @@ constexpr const float SC_LARGER						= 1.22f;
 namespace Mumble
 {
 	extern Identity* IdentityParsed;
+	extern volatile bool SuppressExcessiveParseErrors;
+	extern volatile unsigned int ParserErrorCount;
 
 	///----------------------------------------------------------------------------------------------------
 	/// GetScalingFactor:

--- a/src/Services/Settings/Settings.cpp
+++ b/src/Services/Settings/Settings.cpp
@@ -35,6 +35,7 @@ const char* OPT_LANGUAGE					= "Language";
 const char* OPT_ALWAYSSHOWQUICKACCESS		= "AlwaysShowQuickAccess";
 const char* OPT_GLOBALSCALE					= "GlobalScale";
 const char* OPT_SHOWADDONSWINDOWAFTERDUU	= "ShowAddonsWindowAfterDisableUntilUpdate";
+const char* OPT_SUPPRESS_EXCESSIVE_MUMBLE_PARSE_ERRORS	= "SuppressExcessiveMumbleParseErrors";
 
 namespace Settings
 {

--- a/src/Services/Settings/Settings.h
+++ b/src/Services/Settings/Settings.h
@@ -34,6 +34,7 @@ extern const char* OPT_LANGUAGE;
 extern const char* OPT_ALWAYSSHOWQUICKACCESS;
 extern const char* OPT_GLOBALSCALE;
 extern const char* OPT_SHOWADDONSWINDOWAFTERDUU;
+extern const char* OPT_SUPPRESS_EXCESSIVE_MUMBLE_PARSE_ERRORS;
 
 ///----------------------------------------------------------------------------------------------------
 /// Settings Namespace


### PR DESCRIPTION
When the system is overloaded mumble parsing cannot keep up and constantly produces errors.  

This can be incredibly spammy, and can make it hard to see whats happening besides parsing errors. I just arbitrarily picked a max of 5, this could ofcourse be adjusted.


This does not contain translations for the settings