### PR TITLE
Relax the requirement for addons to either have an Unload handler or DisableHotReloading

### DIFF
--- a/src/Loader/AddonDefinition.cpp
+++ b/src/Loader/AddonDefinition.cpp
@@ -115,10 +115,9 @@ bool AddonDefinition::HasMinimumRequirements()
 		Name &&
 		Author &&
 		Description &&
-		Load &&
-		(HasFlag(EAddonFlags::DisableHotloading) || Unload))
+		Load)
 	{
-		return true;
+		return true;  
 	}
 
 	return false;


### PR DESCRIPTION
This is already accounted for in the actual loader, its is only this check that prevents it.