### PR TITLE
Rotate logs on gamestart

### DIFF
--- a/src/Services/Logging/CFileLogger.h
+++ b/src/Services/Logging/CFileLogger.h
@@ -37,6 +37,7 @@ class CFileLogger : public virtual ILogger
 		void LogMessage(LogEntry aLogEntry);
 
 	private:
+		void rotate(const std::filesystem::path& aPath);
 		std::ofstream File;
 };
 


### PR DESCRIPTION
Don't overwrite old logs, instead rename them. Might need a cleanup function to keep max last 10 logs or sth, or even compress older logs